### PR TITLE
Add support for downloading Odoo 19 image

### DIFF
--- a/src/components/screens/NewInstanceScreen.tsx
+++ b/src/components/screens/NewInstanceScreen.tsx
@@ -124,7 +124,7 @@ const NewInstanceScreen: React.FC = () => {
     ];
 
     const [formData, setFormData] = useState<OdooFormData>({
-        version: '18',
+        version: '19',
         edition: 'Community',
         instanceName: '',
         port: '8069',
@@ -827,7 +827,7 @@ const NewInstanceScreen: React.FC = () => {
                                                     onChange={handleVersionChange}
                                                     disabled={formData.customImage}
                                                 >
-                                                    {['14', '15', '16', '17', '18'].map(version => {
+                                                    {['14', '15', '16', '17', '18', '19'].map(version => {
                                                         const isInstalled = availableImages.some(img =>
                                                             img.name === `odoo:${version}` && img.installed
                                                         );
@@ -845,7 +845,7 @@ const NewInstanceScreen: React.FC = () => {
                                                             >
                                                                 <span>
                                                                     {version}
-                                                                    {version === '18' && t('latestVersion')}
+                                                                    {version === '19' && t('latestVersion')}
                                                                 </span>
                                                                 {!isInstalled && (
                                                                     <Typography

--- a/src/components/screens/SetupScreen.tsx
+++ b/src/components/screens/SetupScreen.tsx
@@ -107,6 +107,7 @@ const initialImages: DockerImage[] = [
     { name: 'odoo:16', installed: true, downloading: false, size: '1.4 GB' },
     { name: 'odoo:17', installed: false, downloading: false, size: '1.5 GB' },
     { name: 'odoo:18', installed: false, downloading: false, size: '1.6 GB' },
+    { name: 'odoo:19', installed: false, downloading: false, size: '1.7 GB' },
     { name: 'postgres:13', installed: false, downloading: false, size: '0.4 GB' },
     { name: 'postgres:14', installed: true, downloading: false, size: '0.5 GB' },
     { name: 'postgres:15', installed: false, downloading: false, size: '0.5 GB' },

--- a/src/services/docker/dockerImagesService.ts
+++ b/src/services/docker/dockerImagesService.ts
@@ -90,6 +90,7 @@ class DockerImagesService {
                 { name: 'odoo:16', size: '1.4 GB' },
                 { name: 'odoo:17', size: '1.5 GB' },
                 { name: 'odoo:18', size: '1.6 GB' },
+                { name: 'odoo:19', size: '1.7 GB' },
                 { name: 'postgres:13', size: '0.4 GB' },
                 { name: 'postgres:14', size: '0.5 GB' },
                 { name: 'postgres:15', size: '0.5 GB' },


### PR DESCRIPTION
## Summary
- include the official `odoo:19` image in the default Docker image recommendations
- make Odoo 19 available for selection when creating new instances and mark it as the latest option

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d829ab8cb08327aecccb30f3270ef2